### PR TITLE
Add support for HTMLSlotElement.assignedElements()

### DIFF
--- a/dom/html/HTMLSlotElement.cpp
+++ b/dom/html/HTMLSlotElement.cpp
@@ -177,6 +177,17 @@ HTMLSlotElement::AssignedNodes(const AssignedNodesOptions& aOptions,
   aNodes = mAssignedNodes;
 }
 
+void HTMLSlotElement::AssignedElements(const AssignedNodesOptions& aOptions,
+			                                 nsTArray<RefPtr<Element>>& aElements) {
+  AutoTArray<RefPtr<nsINode>, 128> assignedNodes;
+  AssignedNodes(aOptions, assignedNodes);
+  for (const RefPtr<nsINode>& assignedNode : assignedNodes) {
+	  if (assignedNode->IsElement()) {
+		  aElements.AppendElement(assignedNode->AsElement());
+		}
+	}
+}
+
 const nsTArray<RefPtr<nsINode>>&
 HTMLSlotElement::AssignedNodes() const
 {

--- a/dom/html/HTMLSlotElement.h
+++ b/dom/html/HTMLSlotElement.h
@@ -55,6 +55,9 @@ public:
   void AssignedNodes(const AssignedNodesOptions& aOptions,
                      nsTArray<RefPtr<nsINode>>& aNodes);
 
+  void AssignedElements(const AssignedNodesOptions& aOptions,
+			                  nsTArray<RefPtr<Element>>& aNodes);
+
   // Helper methods
   const nsTArray<RefPtr<nsINode>>& AssignedNodes() const;
   void InsertAssignedNode(uint32_t aIndex, nsINode* aNode);

--- a/dom/webidl/HTMLSlotElement.webidl
+++ b/dom/webidl/HTMLSlotElement.webidl
@@ -15,6 +15,7 @@
 interface HTMLSlotElement : HTMLElement {
   [CEReactions, SetterThrows] attribute DOMString name;
   sequence<Node> assignedNodes(optional AssignedNodesOptions options);
+  sequence<Element> assignedElements(optional AssignedNodesOptions options);
 };
 
 dictionary AssignedNodesOptions {


### PR DESCRIPTION
The patch for Mozilla bug 1425685 applies cleanly except for testing/web-platform/meta/html/dom/interfaces.https.html.ini. It should still work without it though. https://bugzilla.mozilla.org/show_bug.cgi?id=1425685